### PR TITLE
added logging & use binary temp file

### DIFF
--- a/src/main/java/com/pycriptsocket/EncDec.java
+++ b/src/main/java/com/pycriptsocket/EncDec.java
@@ -1,6 +1,7 @@
 package com.pycriptsocket;
 
 import burp.api.montoya.core.ByteArray;
+import burp.api.montoya.logging.Logging;
 
 public class EncDec {
 
@@ -12,19 +13,18 @@ public class EncDec {
         this.execution = new Execution();
     }
 
-    public ByteArray process(ByteArray content, boolean isEncryption) {
-        String processedContent = content.toString();
-
-        String tempFilePath = tempFile.processData(processedContent);
+    public ByteArray process(ByteArray content, boolean isEncryption, Logging logging) {
+        
+        String tempFilePath = tempFile.processData(content);
 
         String filePath = isEncryption
                 ? UI.getInstance().getEncryptionFilePath()
                 : UI.getInstance().getDecryptionFilePath();
 
-        boolean success = execution.runCommand(filePath, tempFilePath);
+        boolean success = execution.runCommand(filePath, tempFilePath, logging);
 
         if (success) {
-            String updatedContent = tempFile.readFileContent(tempFilePath);
+            byte[] updatedContent = tempFile.readFileContent(tempFilePath);
             boolean isDeleted = tempFile.deleteFile(tempFilePath);
             if (isDeleted) {
                 System.out.println("Temporary file deleted successfully.");
@@ -33,7 +33,7 @@ public class EncDec {
             }
             return ByteArray.byteArray(updatedContent);
         } else {
-            return content;
+                        return content;
         }
     }
 }

--- a/src/main/java/com/pycriptsocket/Execution.java
+++ b/src/main/java/com/pycriptsocket/Execution.java
@@ -4,10 +4,11 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import burp.api.montoya.logging.Logging;
 
 public class Execution {
 
-    public boolean runCommand(String decryptionFilePath, String tempFilePath) {
+    public boolean runCommand(String decryptionFilePath, String tempFilePath, Logging logging) {
         try {
             String languageBinaryPath = UI.getInstance().getLanguageBinaryPath();
             List<String> command = new ArrayList<>();
@@ -29,7 +30,12 @@ public class Execution {
             BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line;
             while ((line = reader.readLine()) != null) {
-                System.out.println(line);
+                logging.logToOutput(line);
+            }
+            BufferedReader errReader = new BufferedReader(
+                new InputStreamReader(process.getErrorStream()));
+            while ((line = errReader.readLine()) != null) {
+                logging.logToError(line);
             }
             int exitCode = process.waitFor();
             return exitCode == 0;

--- a/src/main/java/com/pycriptsocket/TempFile.java
+++ b/src/main/java/com/pycriptsocket/TempFile.java
@@ -1,20 +1,24 @@
 package com.pycriptsocket;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import burp.api.montoya.core.ByteArray;
+
 public class TempFile {
 
-    public String processData(String data) {
+    public String processData(ByteArray data) {
         // Process the decrypted data and save it to a temporary file
         try {
+            byte[] bytes = data.getBytes();
             File tempFile = File.createTempFile("decrypted_", ".txt");
-            FileWriter writer = new FileWriter(tempFile);
-            writer.write(data);
-            writer.close();
+
+            FileOutputStream fos = new FileOutputStream(tempFile);
+            fos.write(bytes);
+            fos.close();
             return tempFile.getAbsolutePath();
         } catch (IOException e) {
             e.printStackTrace();
@@ -22,9 +26,9 @@ public class TempFile {
         }
     }
 
-    public String readFileContent(String filePath) {
+    public byte[] readFileContent(String filePath) {
         try {
-            return new String(Files.readAllBytes(Paths.get(filePath)));
+            return Files.readAllBytes(Paths.get(filePath));
         } catch (IOException e) {
             e.printStackTrace();
             return null;

--- a/src/main/java/com/pycriptsocket/WebSocketRequestEditor.java
+++ b/src/main/java/com/pycriptsocket/WebSocketRequestEditor.java
@@ -9,6 +9,7 @@ import burp.api.montoya.ui.editor.extension.EditorCreationContext;
 import burp.api.montoya.ui.editor.extension.EditorMode;
 import burp.api.montoya.ui.editor.extension.ExtensionProvidedWebSocketMessageEditor;
 import burp.api.montoya.ui.contextmenu.WebSocketMessage;
+import burp.api.montoya.logging.Logging;
 
 import java.awt.*;
 
@@ -16,9 +17,11 @@ class WebSocketRequestEditor implements ExtensionProvidedWebSocketMessageEditor
 {
     private final RawEditor requestEditor;
     private final EncDec encDec = new EncDec();
+    private final Logging logging;
 
     WebSocketRequestEditor(MontoyaApi api, EditorCreationContext creationContext)
     {
+        logging = api.logging();
         if (creationContext.editorMode() == EditorMode.READ_ONLY)
         {
             requestEditor = api.userInterface().createRawEditor(EditorOptions.READ_ONLY);
@@ -31,7 +34,7 @@ class WebSocketRequestEditor implements ExtensionProvidedWebSocketMessageEditor
     @Override
     public ByteArray getMessage() {
         // Use the same instance of EncDec
-        ByteArray encryptedContent = encDec.process(requestEditor.getContents(), true);
+        ByteArray encryptedContent = encDec.process(requestEditor.getContents(), true, logging);
         return encryptedContent;
     }
 
@@ -39,7 +42,7 @@ class WebSocketRequestEditor implements ExtensionProvidedWebSocketMessageEditor
     public void setMessage(WebSocketMessage message) {
         // Use the same instance of EncDec
         ByteArray content = message.payload();
-        ByteArray updatedContent = encDec.process(content, false);
+        ByteArray updatedContent = encDec.process(content, false, logging);
         requestEditor.setContents(updatedContent);
     }
 


### PR DESCRIPTION
hey. 

i wanted to use your extension and had some issues, because binary data was transferred via websockets. writing the binary data as string to the temp file led to data corruptions. that's why i used fileoutputstream.

i also added some logging here and there, using the montaya api.

best regards